### PR TITLE
Fixed URL and modified time for event.

### DIFF
--- a/src/_data/awarenessevents.json
+++ b/src/_data/awarenessevents.json
@@ -14,7 +14,7 @@
   {
     "daySlug": "hardware-freedom-day",
     "name": "Melbourne Hardware Freedom Day",
-    "url": "https://luma.com/e108e3pb",
+    "url": "https://luma.com/e108e3pb?utm_source=Electron-Workshop",
     "date": "2026-04-18",
     "time": "11:00",
     "location": { "city": "Melbourne", "country": "Australia" },

--- a/src/_data/awarenessevents.json
+++ b/src/_data/awarenessevents.json
@@ -16,7 +16,7 @@
     "name": "Melbourne Hardware Freedom Day",
     "url": "https://luma.com/e108e3pb",
     "date": "2026-04-18",
-    "time": "14:00",
+    "time": "11:00",
     "location": { "city": "Melbourne", "country": "Australia" },
     "timezone": "Australia/Melbourne",
     "language": "English",


### PR DESCRIPTION
URL broken from previous commit, with https://luma.com/e108e3pb_&utm_source=Electron%20Workshop_ that caused the bug. Now fixes #75  