### PR TITLE
Closes #82: CVE-2026-41940 transparency notice + provider updates pat…

### DIFF
--- a/src/_data/providerUpdates.json
+++ b/src/_data/providerUpdates.json
@@ -1,0 +1,11 @@
+[
+  {
+    "vendor": "Serversaurus",
+    "date": "2026-05-01",
+    "type": "Security",
+    "status": "Resolved",
+    "title": "CVE-2026-41940 — cPanel Security Advisory",
+    "summary": "A cPanel/WHM vulnerability was patched automatically on 30 April 2026 before disclosure. No exposure to EW-hosted services.",
+    "url": "/posts/cve-2026-41940/"
+  }
+]

--- a/src/offerings/hosting.md
+++ b/src/offerings/hosting.md
@@ -4,6 +4,38 @@ title: Shared Hosting & Maintenance
 permalink: "/offering/hosting/"
 ---
 
-We patch and monitor the stack, handle backups, and keep services running—so your group doesn’t have to.
+<p class="mb-1"><a href="/network/" class="text-decoration-none small"><i class="bi bi-arrow-left me-1"></i>Back to Network</a></p>
 
-<p class="mt-4"><a href="/network/" class="text-decoration-none"><i class="bi bi-arrow-left me-1"></i>Back to Network</a></p>
+<h1 class="h3 fw-bold mt-3 mb-2">Shared Hosting &amp; Maintenance</h1>
+<p class="lead text-secondary mb-4">We patch and monitor the stack, handle backups, and keep services running — so your group doesn't have to.</p>
+
+<p>Hosting for network members is provided through infrastructure partners. We manage the relationship, handle day-to-day maintenance, and stay across security advisories — you get a stable service without the overhead of running it yourself.</p>
+
+---
+
+<h2 class="h5 fw-semibold mt-5 mb-3">Provider Updates</h2>
+<p class="text-secondary mb-4">When infrastructure providers publish advisories or maintenance notices relevant to EW-hosted services, they appear here. Each entry links to the full notice.</p>
+
+{% if providerUpdates.length %}
+<div class="d-flex flex-column gap-3 mb-5">
+  {% for update in providerUpdates %}
+  <div class="d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2 p-3 rounded border border-primary border-opacity-25 bg-light">
+    <div class="d-flex flex-column gap-1">
+      <div class="d-flex align-items-center gap-2 flex-wrap">
+        <span class="fw-semibold small text-primary">{{ update.vendor }}</span>
+        <span class="badge {% if update.type == 'Security' %}text-bg-warning text-dark{% else %}text-bg-secondary{% endif %}">{{ update.type }}</span>
+        <span class="badge {% if update.status == 'Resolved' %}text-bg-success{% elif update.status == 'Active' %}text-bg-danger{% else %}text-bg-secondary{% endif %}">{{ update.status }}</span>
+        <span class="text-secondary small">{{ update.date }}</span>
+      </div>
+      <p class="mb-0 small">
+        <a href="{{ update.url }}" class="text-decoration-none fw-semibold">{{ update.title }}</a>
+      </p>
+      <p class="mb-0 text-secondary small">{{ update.summary }}</p>
+    </div>
+    <a href="{{ update.url }}" class="btn btn-outline-primary btn-sm flex-shrink-0 align-self-start align-self-sm-center">Read more</a>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-secondary small mb-5">No current updates.</p>
+{% endif %}

--- a/src/posts/cve-2026-41940.md
+++ b/src/posts/cve-2026-41940.md
@@ -1,0 +1,37 @@
+---
+layout: base.njk
+title: "CVE-2026-41940 — cPanel Security Advisory"
+description: "Transparency notice regarding CVE-2026-41940, a security vulnerability affecting cPanel and WHM infrastructure. Serversaurus confirmed all EW-hosted services were patched before disclosure."
+permalink: "/posts/cve-2026-41940/"
+---
+
+<div class="mb-4">
+  <a href="/offering/hosting/" class="text-decoration-none small">
+    <i class="bi bi-arrow-left me-1"></i>Back to Shared Hosting & Maintenance
+  </a>
+</div>
+
+<div class="d-flex align-items-center gap-2 mb-2">
+  <span class="badge text-bg-warning text-dark">Security</span>
+  <span class="badge text-bg-success">Resolved</span>
+  <span class="text-secondary small">2026-05-01</span>
+</div>
+
+<h1 class="h3 fw-bold mb-1">CVE-2026-41940 — cPanel Security Advisory</h1>
+<p class="text-secondary mb-4">Infrastructure provider: <strong>Serversaurus</strong></p>
+
+<h2 class="h5 fw-semibold mt-4 mb-2">What was reported</h2>
+<p>A security vulnerability, <strong>CVE-2026-41940</strong>, was disclosed affecting cPanel and WHM infrastructure across the hosting industry. cPanel notified providers as part of coordinated disclosure.</p>
+
+<h2 class="h5 fw-semibold mt-4 mb-2">What Serversaurus confirmed</h2>
+<p>All Serversaurus-hosted cPanel systems received the patched release (<strong>version 11.134.0.20</strong>) via automated updates on <strong>30 April 2026 at approximately 00:01:45 AEST</strong> — before the advisory was widely reported and before our enquiry was received.</p>
+<p>Serversaurus monitors upstream security advisories and applies patches in line with their standard operating procedures. Platform-level updates of this kind are applied centrally and are not issued as individual notifications to tenant-level contacts.</p>
+
+<h2 class="h5 fw-semibold mt-4 mb-2">Outcome</h2>
+<div class="p-3 rounded border border-success border-opacity-25 bg-success bg-opacity-10 mb-4">
+  <p class="mb-0"><i class="bi bi-check-circle-fill text-success me-2"></i><strong>No exposure.</strong> EW-hosted services were on the patched version prior to disclosure. No further action is required.</p>
+</div>
+
+<h2 class="h5 fw-semibold mt-4 mb-2">Why we publish these notices</h2>
+<p>EW's infrastructure runs on services shared across network members. When a security advisory touches that infrastructure, we confirm status with the relevant provider and publish what we find — regardless of outcome. A resolved notice is still worth publishing: it closes the loop for anyone who heard about the advisory and wondered if it applied here.</p>
+<p>Provider updates are listed on the <a href="/offering/hosting/">Shared Hosting &amp; Maintenance</a> page.</p>


### PR DESCRIPTION
…tern

Adds a transparency notice for CVE-2026-41940 (cPanel/WHM). Serversaurus confirmed all EW-hosted services were on the patched version (11.134.0.20) before disclosure — no exposure.

Introduces a Provider Updates pattern on the hosting offering page:
- src/_data/providerUpdates.json — vendor-contributed data file; future providers can publish updates via PR by adding a row
- src/posts/cve-2026-41940.md — full notice at /posts/cve-2026-41940/
- src/offerings/hosting.md — expanded with intro and Provider Updates section that loops over providerUpdates.json