### PR TITLE
Redesign June 2026 Un-forum page layout

### DIFF
--- a/src/assets/events/unforum-june-2026.ics
+++ b/src/assets/events/unforum-june-2026.ics
@@ -45,13 +45,14 @@ BEGIN:VEVENT
 UID:unforum-june-2026-sun@electronworkshop.org
 DTSTAMP:20260619T000000Z
 DTSTART;TZID=Australia/Sydney:20260621T100000
-DTEND;TZID=Australia/Sydney:20260621T170000
+DTEND;TZID=Australia/Sydney:20260621T180000
 SUMMARY:Un-forum — Sunday
 LOCATION:inspire9\, Level 1/41-43 Stewart St\, Richmond VIC 3121
-DESCRIPTION:EW Touch base (Special Edition of Project Check-ins) 10am–11:3
- 0am\, then lunch\, then Unconference 2pm–5pm.\n\nOnline participants: https
- ://evenue.electronworkshop.com.au/rooms/vpu-ci4-ut4-14k/join\n\nMore info:
-  https://electronworkshop.org/unforum-june-2026/
+DESCRIPTION:Morning: Project Check-ins 10am–11:30am (hybrid).\nAfternoon:
+  Unconference 2pm–4pm (parallel in-person & online).\nIGF submissions ses
+ sion 5pm–6pm (hybrid).\n\nOnline: https://evenue.electronworkshop.com.au/r
+ ooms/vpu-ci4-ut4-14k/join\n\nMore info: https://electronworkshop.org/unfor
+ um-june-2026/
 URL:https://electronworkshop.org/unforum-june-2026/
 STATUS:CONFIRMED
 SEQUENCE:0
@@ -68,9 +69,10 @@ DTSTART;TZID=Australia/Sydney:20260622T090000
 DTEND;TZID=Australia/Sydney:20260622T130000
 SUMMARY:Un-forum — Post-forum: Breakfast
 LOCATION:Vinny's Eatery\, Shop 1/860 Collins St\, Docklands VIC 3008
-DESCRIPTION:Breakfast at Vinny's Eatery from 9am\, then a volunteer work s
- ession to consolidate notes\, action plans\, and follow-ups from the unconfe
- rence.\n\nMore info: https://electronworkshop.org/unforum-june-2026/
+DESCRIPTION:Working breakfast at Vinny's Eatery from 9am. Open to all\, ex
+ plicitly for getting things done — consolidate notes\, draft action plans\,
+  follow up on commitments from Sunday.\n\nMore info: https://electronworksh
+ op.org/unforum-june-2026/
 URL:https://electronworkshop.org/unforum-june-2026/
 STATUS:CONFIRMED
 SEQUENCE:0

--- a/src/posts/unforum-june-2026.md
+++ b/src/posts/unforum-june-2026.md
@@ -15,9 +15,6 @@ form:
 ---
 
 <style>
-.dashed-border {
-  border-bottom-style: dashed !important;
-}
 .theme-pill {
   display: inline-block;
   padding: .25rem .75rem;
@@ -54,7 +51,6 @@ form:
     <span class="theme-pill bg-secondary bg-opacity-10 text-secondary-emphasis"><i class="bi bi-diagram-3 me-1"></i>Cooperatives</span>
     <span class="theme-pill bg-dark bg-opacity-10 text-dark"><i class="bi bi-globe me-1"></i>Internet Governance</span>
   </div>
-  <p class="text-secondary small mt-3 mb-0">These themes run through the whole weekend — the unconference on Sunday is where the conversations happen.</p>
 </div>
 
 {# ── CALENDAR ──────────────────────────────────────────────────────────────── #}
@@ -63,217 +59,132 @@ form:
     Add to Calendar (.ics)
   </a>
   <a class="btn btn-outline-primary mb-2 mb-sm-0"
-     href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+June+2026&dates=20260620T080000Z/20260622T040000Z&details=Three+days+in+Melbourne.%0A%0ASat+20+Jun%3A+Dinner+at+Crossways+Food+for+Life%2C+Level+1%2F123+Swanston+St%2C+Melbourne+CBD.+Drop+in+from+6pm.%0ASun+21+Jun%3A+EW+Touch+base+10am%E2%80%9311%3A30am+%2B+Unconference+2pm%E2%80%935pm+at+inspire9%2C+Richmond.%0AMon+22+Jun%3A+Breakfast+at+Vinny%27s+Eatery%2C+860+Collins+St%2C+Docklands+from+9am+%2B+volunteer+work+session.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=Melbourne&ctz=Australia/Sydney"
+     href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+June+2026&dates=20260620T080000Z/20260622T040000Z&details=Three+days+in+Melbourne.%0A%0ASat+20+Jun%3A+Dinner+at+Crossways+Food+for+Life%2C+Level+1%2F123+Swanston+St%2C+Melbourne+CBD.+Drop+in+from+6pm.%0ASun+21+Jun%3A+EW+Touch+base+10am%E2%80%9311%3A30am+%2B+Unconference+2pm%E2%80%934pm+at+inspire9%2C+Richmond+%2B+online.+IGF+session+5pm%E2%80%936pm+hybrid.%0AMon+22+Jun%3A+Working+breakfast+at+Vinny%27s+Eatery%2C+860+Collins+St%2C+Docklands+from+9am.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=Melbourne&ctz=Australia/Sydney"
      target="_blank" rel="noopener">
     Add to Google Calendar
   </a>
   <p class="small text-secondary mt-2 mb-0">
     Individual days &mdash; Google Calendar:
     <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Saturday+Dinner&dates=20260620T080000Z/20260620T120000Z&details=Dinner+at+Crossways+Food+for+Life.+Drop+in+from+6pm.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=Level+1%2C+123+Swanston+St%2C+Melbourne+VIC+3000&ctz=Australia/Sydney" target="_blank" rel="noopener">Saturday</a>,
-    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Sunday+Unconference&dates=20260621T000000Z/20260621T070000Z&details=EW+Touch+base+10am%E2%80%9311%3A30am+%2B+Unconference+2pm%E2%80%935pm+(hybrid+from+4pm).%0AOnline%3A+https%3A%2F%2Fevenue.electronworkshop.com.au%2Frooms%2Fvpu-ci4-ut4-14k%2Fjoin%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=inspire9%2C+41-43+Stewart+St%2C+Richmond+VIC+3121&ctz=Australia/Sydney" target="_blank" rel="noopener">Sunday</a>,
-    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Monday+Breakfast+%26+Work+Session&dates=20260621T230000Z/20260622T040000Z&details=Breakfast+at+Vinny%27s+Eatery+from+9am%2C+then+volunteer+work+session.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=Shop+1%2F860+Collins+St%2C+Docklands+VIC+3008&ctz=Australia/Sydney" target="_blank" rel="noopener">Monday</a>
+    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Sunday&dates=20260621T000000Z/20260621T080000Z&details=Morning%3A+Project+Check-ins+10am%E2%80%9311%3A30am+(hybrid).%0AAfternoon%3A+Unconference+2pm%E2%80%934pm+(parallel+in-person+%26+online).%0AIGF+submissions+session+5pm%E2%80%936pm+(hybrid).%0A%0AOnline%3A+https%3A%2F%2Fevenue.electronworkshop.com.au%2Frooms%2Fvpu-ci4-ut4-14k%2Fjoin%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=inspire9%2C+41-43+Stewart+St%2C+Richmond+VIC+3121&ctz=Australia/Sydney" target="_blank" rel="noopener">Sunday</a>,
+    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Working+Breakfast&dates=20260621T230000Z/20260622T040000Z&details=Working+breakfast+at+Vinny%27s+Eatery+from+9am.+Open+to+all+%E2%80%94+bring+something+to+work+on.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-june-2026%2F&location=Shop+1%2F860+Collins+St%2C+Docklands+VIC+3008&ctz=Australia/Sydney" target="_blank" rel="noopener">Monday</a>
   </p>
 </div>
 
-{# ── DAY CARDS ────────────────────────────────────────────────────────────── #}
-<div class="row g-4 mb-4 mt-1">
+{# ── PRE-FORUM: DINNER ────────────────────────────────────────────────────── #}
+<div class="mb-3 p-3 rounded border bg-light">
+  <div class="d-flex flex-wrap align-items-baseline gap-2 mb-1">
+    <span class="fw-bold text-primary">Pre-forum: Dinner</span>
+    <span class="text-secondary small">Saturday 20 June &middot; drop in from 6:00pm</span>
+    <span class="badge text-bg-success ms-auto">In person</span>
+  </div>
+  <p class="small mb-1">
+    <span class="fw-semibold">Crossways Food for Life</span>
+    <span class="text-secondary ms-1">Level 1, 123 Swanston St, Melbourne CBD</span>
+    &middot;
+    <a href="https://www.google.com/maps/search/Crossways+Food+for+Life,+123+Swanston+St,+Melbourne+VIC+3000" target="_blank" rel="noopener" class="small">Google Maps</a>
+    &middot;
+    <a href="https://www.openstreetmap.org/node/2442071635" target="_blank" rel="noopener" class="small">OSM</a>
+  </p>
+  <p class="small text-secondary mb-0">No agenda — arrive when you can, eat, meet people.</p>
+</div>
 
-  {# ── DAY 1 — DINNER ───────────────────────────────────────────────────── #}
-  <div class="col-12 col-lg-4">
-    <div class="card h-100 bg-light overflow-hidden">
-      <div class="card-header bg-primary text-white">
-        <h5 class="card-title mb-0">Pre-forum: Dinner</h5>
-      </div>
-      <div class="card-body p-0">
+{# ── UN-FORUM ──────────────────────────────────────────────────────────────── #}
+<div class="mb-3 rounded border border-primary overflow-hidden">
 
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <h5 class="card-title mb-0 text-primary fw-bold">
-            <i class="bi bi-calendar3" aria-hidden="true"></i> Saturday 20th June 2026
-          </h5>
-        </div>
+  <div class="p-3 bg-primary text-white">
+    <h4 class="mb-0">Un-forum <span class="fw-normal opacity-75 fs-6">&mdash; Sunday 21 June</span></h4>
+  </div>
 
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="mb-0 text-secondary small">A relaxed dinner to open the weekend — no agenda, just a warm-up for Sunday. Come when you can.</p>
-        </div>
-
-        {# Venue #}
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Venue</p>
-          <p class="fw-semibold mb-1 small">Crossways Food for Life</p>
-          <p class="mb-1 small text-secondary">Level 1, 123 Swanston St, Melbourne CBD</p>
-          <p class="mb-0 small">
-            <a href="https://www.google.com/maps/search/Crossways+Food+for+Life,+123+Swanston+St,+Melbourne+VIC+3000" target="_blank" rel="noopener">Google Maps</a>
-            &middot;
-            <a href="https://www.openstreetmap.org/node/2442071635" target="_blank" rel="noopener">OpenStreetMap</a>
-          </p>
-        </div>
-
-        {# Agenda #}
-        <div class="p-3 bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Agenda</p>
-          <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">Drop in from 6:00pm</span>
-          </div>
-          <div class="mb-2">
-            <span class="badge text-bg-success">In person</span>
-          </div>
-          <p class="mb-0 small text-secondary">No agenda — just arrive, eat, and meet people.</p>
-        </div>
-
-      </div>
+  <div class="p-3 border-bottom d-flex flex-wrap gap-4 bg-light">
+    <div>
+      <p class="text-primary fw-bold text-uppercase mb-1" style="letter-spacing:.08em; font-size:.75rem;">In person</p>
+      <p class="fw-semibold mb-0 small">inspire9</p>
+      <p class="small text-secondary mb-0">
+        Level 1/41–43 Stewart St, Richmond VIC 3121
+        &middot;
+        <a href="https://www.google.com/maps/search/inspire9,+41-43+Stewart+St,+Richmond+VIC+3121" target="_blank" rel="noopener">Google Maps</a>
+        &middot;
+        <a href="https://www.openstreetmap.org/search?query=inspire9+41+Stewart+Street+Richmond+Victoria" target="_blank" rel="noopener">OSM</a>
+      </p>
+    </div>
+    <div>
+      <p class="text-primary fw-bold text-uppercase mb-1" style="letter-spacing:.08em; font-size:.75rem;">Online</p>
+      <p class="fw-semibold mb-0 small">eVenue</p>
+      <p class="small text-secondary mb-0">
+        <a href="https://evenue.electronworkshop.com.au/rooms/vpu-ci4-ut4-14k/join" target="_blank" rel="noopener">Join online</a>
+      </p>
     </div>
   </div>
 
-  {# ── DAY 2 — UNCONFERENCE ─────────────────────────────────────────────── #}
-  <div class="col-12 col-lg-4">
-    <div class="card h-100 bg-light overflow-hidden">
-      <div class="card-header bg-primary text-white">
-        <h5 class="card-title mb-0">Un-forum</h5>
-      </div>
-      <div class="card-body p-0">
+  {# Morning #}
+  <div class="p-4 border-bottom">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+      <span class="text-primary fw-bold text-uppercase" style="letter-spacing:.08em; font-size:.75rem;">Morning</span>
+      <span class="text-secondary small">10:00am &ndash; 11:30am</span>
+      <span class="badge bg-info text-dark">Hybrid <i class="bi bi-broadcast-pin ms-1" aria-hidden="true"></i></span>
+    </div>
+    <p class="fw-semibold mb-1">Project Check-ins</p>
+    <p class="small text-secondary mb-0">A structured round of updates from across the Electron Workshop network — what is everyone working on?</p>
+  </div>
 
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <h5 class="card-title mb-0 text-primary fw-bold">
-            <i class="bi bi-calendar3" aria-hidden="true"></i> Sunday 21st June 2026
-          </h5>
-        </div>
+  {# Afternoon #}
+  <div class="p-4">
+    <p class="text-primary fw-bold text-uppercase mb-3" style="letter-spacing:.08em; font-size:.75rem;">Afternoon</p>
 
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="mb-0 text-secondary small">The main event. Morning touch base, lunch, then a full afternoon unconference — participant-driven from start to finish.</p>
-        </div>
-
-        {# Venue #}
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Venue</p>
-          <p class="fw-semibold mb-1 small"><i class="bi bi-building me-1"></i>inspire9</p>
-          <p class="mb-1 small text-secondary">Level 1, 41–43 Stewart St, Richmond VIC 3121</p>
-          <p class="mb-2 small">
-            <a href="https://www.google.com/maps/search/inspire9,+41-43+Stewart+St,+Richmond+VIC+3121" target="_blank" rel="noopener">Google Maps</a>
-            &middot;
-            <a href="https://www.openstreetmap.org/search?query=inspire9+41+Stewart+Street+Richmond+Victoria" target="_blank" rel="noopener">OpenStreetMap</a>
-          </p>
-          <p class="fw-semibold mb-1 small"><i class="bi bi-camera-video me-1"></i>Online — Coworking Room</p>
-          <p class="mb-0 small">
-            <a href="https://evenue.electronworkshop.com.au/rooms/vpu-ci4-ut4-14k/join" target="_blank" rel="noopener">Join online</a>
-          </p>
-        </div>
-
-        {# Agenda #}
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Agenda</p>
+    {# 2pm–4pm parallel streams #}
+    <div class="row g-3 mb-3">
+      <div class="col-12 col-sm-6">
+        <div class="p-3 rounded border h-100">
           <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">10:00am &ndash; 11:30am</span>
-          </div>
-          <div class="mb-2">
-            <span class="badge bg-info text-dark">Hybrid <i class="bi bi-broadcast-pin ms-1"></i></span>
-          </div>
-          <p class="fw-semibold mb-1 small">
-            <i class="bi bi-people-fill me-1 text-primary"></i>
-            EW Touch base &mdash; Special Edition of Project Check-ins
-          </p>
-          <p class="mb-0 small text-secondary">What is everyone working on? A structured round of project updates from across the Electron Workshop network.</p>
-        </div>
-
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">Lunch</span>
-          </div>
-          <div class="mb-2">
+            <span class="small text-secondary fw-semibold">2:00pm &ndash; 4:00pm</span>
             <span class="badge text-bg-success">In person</span>
           </div>
-          <p class="mb-0 small text-secondary">Head somewhere local in Richmond, or stay and graze on snacks at inspire9.</p>
+          <p class="fw-semibold mb-1 small">Unconference</p>
+          <p class="small text-secondary mb-0">Participant-driven sessions at inspire9. Pitch a topic, follow a thread, or just show up.</p>
         </div>
-
-        <div class="p-3 bg-light">
-          <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">2:00pm &ndash; 5:00pm</span>
-          </div>
-          <div class="mb-2">
-            <span class="badge text-bg-success">In person</span>
-            <span class="badge bg-info text-dark ms-1">Online from 4pm <i class="bi bi-broadcast-pin ms-1"></i></span>
-          </div>
-          <p class="fw-semibold mb-1 small">
-            <i class="bi bi-journal-text me-1 text-primary"></i>
-            Unconference
-          </p>
-          <p class="mb-1 small text-secondary">Participant-driven sessions across the themes and wherever the conversations go. Pitch a topic, follow a thread, or just show up.</p>
-          <p class="mb-0 small text-secondary">The 4:00pm &ndash; 4:40pm slot is also streamed online.</p>
-        </div>
-
       </div>
+      <div class="col-12 col-sm-6">
+        <div class="p-3 rounded border h-100">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span class="small text-secondary fw-semibold">2:00pm &ndash; 4:00pm</span>
+            <span class="badge bg-secondary">Online</span>
+          </div>
+          <p class="fw-semibold mb-1 small">Unconference</p>
+          <p class="small text-secondary mb-0">Parallel online stream — same format, separate room.</p>
+        </div>
+      </div>
+    </div>
+
+    {# 5pm–6pm hybrid IGF #}
+    <div class="p-3 rounded border">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <span class="small text-secondary fw-semibold">5:00pm &ndash; 6:00pm</span>
+        <span class="badge bg-info text-dark">Hybrid <i class="bi bi-broadcast-pin ms-1" aria-hidden="true"></i></span>
+      </div>
+      <p class="fw-semibold mb-1 small">Internet Governance Forum &mdash; Submissions Session</p>
+      <p class="small text-secondary mb-0">A focused session for drafting and reviewing submissions to the Internet Governance Forum.</p>
     </div>
   </div>
 
-  {# ── DAY 3 — BREAKFAST ────────────────────────────────────────────────── #}
-  <div class="col-12 col-lg-4">
-    <div class="card h-100 bg-light overflow-hidden">
-      <div class="card-header bg-primary text-white">
-        <h5 class="card-title mb-0">Post-forum: Breakfast</h5>
-      </div>
-      <div class="card-body p-0">
+</div>
 
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <h5 class="card-title mb-0 text-primary fw-bold">
-            <i class="bi bi-calendar3" aria-hidden="true"></i> Monday 22nd June 2026
-          </h5>
-        </div>
-
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="mb-0 text-secondary small">A low-key close to the weekend — breakfast in Docklands, then a working session for anyone who wants to help turn Sunday's conversations into something lasting.</p>
-        </div>
-
-        {# Venue #}
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Venue</p>
-          <p class="fw-semibold mb-1 small">Vinny's Eatery</p>
-          <p class="mb-1 small text-secondary">Shop 1/860 Collins St, Docklands VIC 3008</p>
-          <p class="mb-0 small">
-            <a href="https://www.google.com/maps/search/Vinny's+Eatery,+860+Collins+St,+Docklands+VIC+3008" target="_blank" rel="noopener">Google Maps</a>
-            &middot;
-            <a href="https://www.openstreetmap.org/?mlat=-37.820957&mlon=144.94376&zoom=18" target="_blank" rel="noopener">OpenStreetMap</a>
-          </p>
-        </div>
-
-        {# Agenda #}
-        <div class="p-3 border-bottom dashed-border bg-light">
-          <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.06em; font-size:.75rem;">Agenda</p>
-          <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">9:00am</span>
-          </div>
-          <div class="mb-2">
-            <span class="badge text-bg-success">In person</span>
-          </div>
-          <p class="fw-semibold mb-1 small">
-            <i class="bi bi-egg-fried me-1 text-warning-emphasis"></i>
-            Breakfast
-          </p>
-          <p class="mb-0 small text-secondary">A relaxed start — eat, debrief, and wind down from the weekend.</p>
-        </div>
-
-        <div class="p-3 bg-light">
-          <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-clock text-primary" aria-hidden="true"></i>
-            <span class="fw-bold">After breakfast</span>
-          </div>
-          <div class="mb-2">
-            <span class="badge text-bg-success">In person</span>
-          </div>
-          <p class="fw-semibold mb-1 small">
-            <i class="bi bi-pencil-square me-1 text-primary"></i>
-            Volunteer work session
-          </p>
-          <p class="mb-0 small text-secondary">For those who want to stick around — consolidate notes from the unconference, draft action plans, and follow up on commitments made over the weekend. Open to all volunteers.</p>
-        </div>
-
-      </div>
-    </div>
+{# ── POST-FORUM: BREAKFAST ─────────────────────────────────────────────────── #}
+<div class="mb-4 p-3 rounded border bg-light">
+  <div class="d-flex flex-wrap align-items-baseline gap-2 mb-1">
+    <span class="fw-bold text-primary">Post-forum: Breakfast</span>
+    <span class="text-secondary small">Monday 22 June &middot; from 9:00am</span>
+    <span class="badge text-bg-success ms-auto">In person</span>
   </div>
-
+  <p class="small mb-1">
+    <span class="fw-semibold">Vinny's Eatery</span>
+    <span class="text-secondary ms-1">Shop 1/860 Collins St, Docklands VIC 3008</span>
+    &middot;
+    <a href="https://www.google.com/maps/search/Vinny's+Eatery,+860+Collins+St,+Docklands+VIC+3008" target="_blank" rel="noopener" class="small">Google Maps</a>
+    &middot;
+    <a href="https://www.openstreetmap.org/?mlat=-37.820957&mlon=144.94376&zoom=18" target="_blank" rel="noopener" class="small">OSM</a>
+  </p>
+  <p class="small text-secondary mb-0">Working session — open to all, explicitly for getting things done. Consolidate notes, draft action plans, follow up on commitments from Sunday.</p>
 </div>
 
 <p class="mb-4 text-secondary">RSVP links will be added shortly. Subscribe below to stay across updates.</p>


### PR DESCRIPTION
Replace three equal-weight day cards with a hierarchy that reflects the actual event structure: compact bookend strips for the dinner and breakfast, full-width Un-forum card as the centrepiece.

Un-forum card has a clean header (date only), a venue row treating in-person (inspire9) and online (eVenue) as parallel entries, then morning and afternoon sections clearly delineated. Afternoon shows the 2–4pm parallel in-person/online streams as side-by-side cards, with the 5–6pm hybrid IGF submissions session as a full-width block below.

Monday framed as a working session open to all, explicitly not social. ICS updated to match revised schedule and descriptions.