### PR TITLE
homepage: feature the next Un-forum (September 2026)

### DIFF
--- a/src/_data/homeCards.json
+++ b/src/_data/homeCards.json
@@ -2,11 +2,20 @@
   {
     "cardType": "whatsOnEcosystem",
     "featured": true,
+    "title": "Un-forum — September 2026",
+    "text": "Unconference on Sunday 20 September (Online and Richmond) | Dinner Saturday evening, breakfast Monday | Software Freedom Day weekend",
+    "href": "/unforum-sept-2026/",
+    "button": "See the program",
+    "tags": ["software-freedom", "open-source", "privacy", "right-to-repair", "cooperatives", "internet-governance", "free"]
+  },
+  {
+    "cardType": "whatsOnEcosystem",
     "title": "Un-forum — June 2026",
     "text": "Unconference on Sunday 21 June (Online and Richmond) | Dinner Saturday evening, breakfast Monday",
     "href": "/unforum-june-2026/",
     "button": "See the program",
-    "tags": ["social-enterprise", "local-economy", "privacy", "local-ai", "cooperatives", "internet-governance", "free"]
+    "tags": ["social-enterprise", "local-economy", "privacy", "local-ai", "cooperatives", "internet-governance", "free"],
+    "past": true
   },
   {
     "cardType": "whatsOnEcosystem",

--- a/src/assets/events/unforum-sept-2026.ics
+++ b/src/assets/events/unforum-sept-2026.ics
@@ -1,0 +1,85 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Electron Workshop//Un-forum September 2026//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Un-forum September 2026
+X-WR-TIMEZONE:Australia/Sydney
+BEGIN:VTIMEZONE
+TZID:Australia/Sydney
+BEGIN:STANDARD
+TZOFFSETFROM:+1100
+TZOFFSETTO:+1000
+TZNAME:AEST
+DTSTART:19700405T030000
+RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU
+END:STANDARD
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+1000
+TZOFFSETTO:+1100
+TZNAME:AEDT
+DTSTART:19701004T020000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:unforum-sept-2026-sat@electronworkshop.org
+DTSTAMP:20260918T000000Z
+DTSTART;TZID=Australia/Sydney:20260919T180000
+DTEND;TZID=Australia/Sydney:20260919T220000
+SUMMARY:Un-forum — Pre-forum: Dinner
+LOCATION:Crossways Food for Life\, Level 1/123 Swanston St\, Melbourne VIC 3000
+DESCRIPTION:Dinner at Crossways Food for Life. Drop in from 6pm. No agenda
+ — just a warm-up for Sunday's un-forum.\n\nMore info: https://electronwork
+ shop.org/unforum-sept-2026/
+URL:https://electronworkshop.org/unforum-sept-2026/
+STATUS:CONFIRMED
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT60M
+ACTION:DISPLAY
+DESCRIPTION:Reminder: Un-forum dinner starts in 1 hour
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:unforum-sept-2026-sun@electronworkshop.org
+DTSTAMP:20260918T000000Z
+DTSTART;TZID=Australia/Sydney:20260920T100000
+DTEND;TZID=Australia/Sydney:20260920T180000
+SUMMARY:Un-forum — Sunday
+LOCATION:inspire9\, Level 1/41-43 Stewart St\, Richmond VIC 3121
+DESCRIPTION:Morning: Project Check-ins 10am–11:30am (hybrid).\nAfternoon:
+  Unconference 2pm–4pm (parallel in-person & online).\nIGF submissions ses
+ sion 5pm–6pm (hybrid).\n\nOnline: https://evenue.electronworkshop.com.au/r
+ ooms/vpu-ci4-ut4-14k/join\n\nMore info: https://electronworkshop.org/unfor
+ um-sept-2026/
+URL:https://electronworkshop.org/unforum-sept-2026/
+STATUS:CONFIRMED
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:Reminder: Un-forum unconference starts in 30 minutes
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:unforum-sept-2026-mon@electronworkshop.org
+DTSTAMP:20260918T000000Z
+DTSTART;TZID=Australia/Sydney:20260921T090000
+DTEND;TZID=Australia/Sydney:20260921T130000
+SUMMARY:Un-forum — Post-forum: Breakfast
+LOCATION:Vinny's Eatery\, Shop 1/860 Collins St\, Docklands VIC 3008
+DESCRIPTION:Working breakfast at Vinny's Eatery from 9am. Open to all\, ex
+ plicitly for getting things done — consolidate notes\, draft action plans\,
+  follow up on commitments from Sunday.\n\nMore info: https://electronworksh
+ op.org/unforum-sept-2026/
+URL:https://electronworkshop.org/unforum-sept-2026/
+STATUS:CONFIRMED
+SEQUENCE:0
+BEGIN:VALARM
+TRIGGER:-PT30M
+ACTION:DISPLAY
+DESCRIPTION:Reminder: Un-forum breakfast in 30 minutes
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/src/posts/unforum-sept-2026.md
+++ b/src/posts/unforum-sept-2026.md
@@ -1,0 +1,190 @@
+---
+layout: base.njk
+title: Un-forum — September 2026
+description: Dinner in the CBD, an unconference at inspire9 Richmond, and a working breakfast in Docklands — three days in Melbourne, 19–21 September 2026
+permalink: "/unforum-sept-2026/"
+preview_image: "https://electronworkshop.org/assets/images/banners/Unforum-2026-Banner-Preview-V100-June.png"
+
+form:
+  heading: "Subscribe to Un-forum Updates"
+  description: "Want to follow along and get updates about the September Un-forum? Enter your email below."
+  formName: "unforumSept2026Form"
+  formId: "unforumSept2026Form"
+  emailId: "unforumSept2026Email"
+  buttonText: "Subscribe"
+---
+
+<style>
+.theme-pill {
+  display: inline-block;
+  padding: .25rem .75rem;
+  border-radius: 2rem;
+  font-size: .8rem;
+  font-weight: 600;
+  letter-spacing: .04em;
+}
+</style>
+
+<h1 class="text-primary">{{title}}</h1>
+
+<p class="mb-1">
+  <a href="/unforum-june-2026/" class="text-primary">
+    <i class="bi bi-arrow-left-circle" aria-hidden="true"></i>
+    Previous Un-forum: 2026-June
+  </a>
+</p>
+<p class="mb-1">
+  <i class="bi bi-calendar3" aria-hidden="true"></i> Saturday to Monday, 19th–21st September 2026
+</p>
+<p class="mb-3">
+  <i class="bi bi-broadcast-pin" aria-hidden="true"></i> Online and in person in Melbourne (CBD / Docklands / Richmond)
+</p>
+
+{# ── THEMES ───────────────────────────────────────────────────────────────── #}
+<div class="mb-4 p-4 rounded border border-primary border-opacity-25 bg-light">
+  <p class="text-primary fw-bold text-uppercase mb-2" style="letter-spacing:.08em; font-size:.8rem;">This edition's themes</p>
+  <div class="d-flex flex-wrap gap-2">
+    <span class="theme-pill bg-primary bg-opacity-10 text-primary"><i class="bi bi-unlock-fill me-1"></i>Software Freedom</span>
+    <span class="theme-pill bg-success bg-opacity-10 text-success"><i class="bi bi-code-square me-1"></i>Open Source</span>
+    <span class="theme-pill bg-warning bg-opacity-10 text-warning-emphasis"><i class="bi bi-shield-lock me-1"></i>Privacy</span>
+    <span class="theme-pill bg-info bg-opacity-10 text-info-emphasis"><i class="bi bi-tools me-1"></i>Right to Repair</span>
+    <span class="theme-pill bg-secondary bg-opacity-10 text-secondary-emphasis"><i class="bi bi-diagram-3 me-1"></i>Cooperatives</span>
+    <span class="theme-pill bg-dark bg-opacity-10 text-dark"><i class="bi bi-globe me-1"></i>Internet Governance</span>
+  </div>
+</div>
+
+{# ── CALENDAR ──────────────────────────────────────────────────────────────── #}
+<div class="mt-3 mb-4">
+  <a class="btn btn-outline-primary me-2 mb-2 mb-sm-0" href="/assets/events/unforum-sept-2026.ics" download>
+    Add to Calendar (.ics)
+  </a>
+  <a class="btn btn-outline-primary mb-2 mb-sm-0"
+     href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+September+2026&dates=20260919T080000Z/20260921T040000Z&details=Three+days+in+Melbourne.%0A%0ASat+19+Sep%3A+Dinner+at+Crossways+Food+for+Life%2C+Level+1%2F123+Swanston+St%2C+Melbourne+CBD.+Drop+in+from+6pm.%0ASun+20+Sep%3A+EW+Touch+base+10am%E2%80%9311%3A30am+%2B+Unconference+2pm%E2%80%934pm+at+inspire9%2C+Richmond+%2B+online.+IGF+session+5pm%E2%80%936pm+hybrid.%0AMon+21+Sep%3A+Working+breakfast+at+Vinny%27s+Eatery%2C+860+Collins+St%2C+Docklands+from+9am.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-sept-2026%2F&location=Melbourne&ctz=Australia/Sydney"
+     target="_blank" rel="noopener">
+    Add to Google Calendar
+  </a>
+  <p class="small text-secondary mt-2 mb-0">
+    Individual days &mdash; Google Calendar:
+    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Saturday+Dinner&dates=20260919T080000Z/20260919T120000Z&details=Dinner+at+Crossways+Food+for+Life.+Drop+in+from+6pm.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-sept-2026%2F&location=Level+1%2C+123+Swanston+St%2C+Melbourne+VIC+3000&ctz=Australia/Sydney" target="_blank" rel="noopener">Saturday</a>,
+    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Sunday&dates=20260920T000000Z/20260920T080000Z&details=Morning%3A+Project+Check-ins+10am%E2%80%9311%3A30am+(hybrid).%0AAfternoon%3A+Unconference+2pm%E2%80%934pm+(parallel+in-person+%26+online).%0AIGF+submissions+session+5pm%E2%80%936pm+(hybrid).%0A%0AOnline%3A+https%3A%2F%2Fevenue.electronworkshop.com.au%2Frooms%2Fvpu-ci4-ut4-14k%2Fjoin%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-sept-2026%2F&location=inspire9%2C+41-43+Stewart+St%2C+Richmond+VIC+3121&ctz=Australia/Sydney" target="_blank" rel="noopener">Sunday</a>,
+    <a href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Un-forum+%E2%80%94+Working+Breakfast&dates=20260920T230000Z/20260921T040000Z&details=Working+breakfast+at+Vinny%27s+Eatery+from+9am.+Open+to+all+%E2%80%94+bring+something+to+work+on.%0A%0AMore+info%3A+https%3A%2F%2Felectronworkshop.org%2Funforum-sept-2026%2F&location=Shop+1%2F860+Collins+St%2C+Docklands+VIC+3008&ctz=Australia/Sydney" target="_blank" rel="noopener">Monday</a>
+  </p>
+</div>
+
+{# ── PRE-FORUM: DINNER ────────────────────────────────────────────────────── #}
+<div class="mb-3 p-3 rounded border bg-light">
+  <div class="d-flex flex-wrap align-items-baseline gap-2 mb-1">
+    <span class="fw-bold text-primary">Pre-forum: Dinner</span>
+    <span class="text-secondary small">Saturday 19 September &middot; drop in from 6:00pm</span>
+    <span class="badge text-bg-success ms-auto">In person</span>
+  </div>
+  <p class="small mb-1">
+    <span class="fw-semibold">Crossways Food for Life</span>
+    <span class="text-secondary ms-1">Level 1, 123 Swanston St, Melbourne CBD</span>
+    &middot;
+    <a href="https://www.google.com/maps/search/Crossways+Food+for+Life,+123+Swanston+St,+Melbourne+VIC+3000" target="_blank" rel="noopener" class="small">Google Maps</a>
+    &middot;
+    <a href="https://www.openstreetmap.org/node/2442071635" target="_blank" rel="noopener" class="small">OSM</a>
+  </p>
+  <p class="small text-secondary mb-0">No agenda — arrive when you can, eat, meet people.</p>
+</div>
+
+{# ── UN-FORUM ──────────────────────────────────────────────────────────────── #}
+<div class="mb-3 rounded border border-primary overflow-hidden">
+
+  <div class="p-3 bg-primary text-white">
+    <h4 class="mb-0">Un-forum <span class="fw-normal opacity-75 fs-6">&mdash; Sunday 20 September</span></h4>
+  </div>
+
+  <div class="p-3 border-bottom d-flex flex-wrap gap-4 bg-light">
+    <div>
+      <p class="text-primary fw-bold text-uppercase mb-1" style="letter-spacing:.08em; font-size:.75rem;">In person</p>
+      <p class="fw-semibold mb-0 small">inspire9</p>
+      <p class="small text-secondary mb-0">
+        Level 1/41–43 Stewart St, Richmond VIC 3121
+        &middot;
+        <a href="https://www.google.com/maps/search/inspire9,+41-43+Stewart+St,+Richmond+VIC+3121" target="_blank" rel="noopener">Google Maps</a>
+        &middot;
+        <a href="https://www.openstreetmap.org/search?query=inspire9+41+Stewart+Street+Richmond+Victoria" target="_blank" rel="noopener">OSM</a>
+      </p>
+    </div>
+    <div>
+      <p class="text-primary fw-bold text-uppercase mb-1" style="letter-spacing:.08em; font-size:.75rem;">Online</p>
+      <p class="fw-semibold mb-0 small">eVenue</p>
+      <p class="small text-secondary mb-0">
+        <a href="https://evenue.electronworkshop.com.au/rooms/vpu-ci4-ut4-14k/join" target="_blank" rel="noopener">Join online</a>
+      </p>
+    </div>
+  </div>
+
+  {# Morning #}
+  <div class="p-4 border-bottom">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+      <span class="text-primary fw-bold text-uppercase" style="letter-spacing:.08em; font-size:.75rem;">Morning</span>
+      <span class="text-secondary small">10:00am &ndash; 11:30am</span>
+      <span class="badge bg-info text-dark">Hybrid <i class="bi bi-broadcast-pin ms-1" aria-hidden="true"></i></span>
+    </div>
+    <p class="fw-semibold mb-1">Project Check-ins</p>
+    <p class="small text-secondary mb-0">A structured round of updates from across the Electron Workshop network — what is everyone working on?</p>
+  </div>
+
+  {# Afternoon #}
+  <div class="p-4">
+    <p class="text-primary fw-bold text-uppercase mb-3" style="letter-spacing:.08em; font-size:.75rem;">Afternoon</p>
+
+    {# 2pm–4pm parallel streams #}
+    <div class="row g-3 mb-3">
+      <div class="col-12 col-sm-6">
+        <div class="p-3 rounded border h-100">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span class="small text-secondary fw-semibold">2:00pm &ndash; 4:00pm</span>
+            <span class="badge text-bg-success">In person</span>
+          </div>
+          <p class="fw-semibold mb-1 small">Unconference</p>
+          <p class="small text-secondary mb-0">Participant-driven sessions at inspire9. Pitch a topic, follow a thread, or just show up.</p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="p-3 rounded border h-100">
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <span class="small text-secondary fw-semibold">2:00pm &ndash; 4:00pm</span>
+            <span class="badge bg-secondary">Online</span>
+          </div>
+          <p class="fw-semibold mb-1 small">Unconference</p>
+          <p class="small text-secondary mb-0">Parallel online stream — same format, separate room.</p>
+        </div>
+      </div>
+    </div>
+
+    {# 5pm–6pm hybrid IGF #}
+    <div class="p-3 rounded border">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <span class="small text-secondary fw-semibold">5:00pm &ndash; 6:00pm</span>
+        <span class="badge bg-info text-dark">Hybrid <i class="bi bi-broadcast-pin ms-1" aria-hidden="true"></i></span>
+      </div>
+      <p class="fw-semibold mb-1 small">Internet Governance Forum &mdash; Submissions Session</p>
+      <p class="small text-secondary mb-0">A focused session for drafting and reviewing submissions to the Internet Governance Forum.</p>
+    </div>
+  </div>
+
+</div>
+
+{# ── POST-FORUM: BREAKFAST ─────────────────────────────────────────────────── #}
+<div class="mb-4 p-3 rounded border bg-light">
+  <div class="d-flex flex-wrap align-items-baseline gap-2 mb-1">
+    <span class="fw-bold text-primary">Post-forum: Breakfast</span>
+    <span class="text-secondary small">Monday 21 September &middot; from 9:00am</span>
+    <span class="badge text-bg-success ms-auto">In person</span>
+  </div>
+  <p class="small mb-1">
+    <span class="fw-semibold">Vinny's Eatery</span>
+    <span class="text-secondary ms-1">Shop 1/860 Collins St, Docklands VIC 3008</span>
+    &middot;
+    <a href="https://www.google.com/maps/search/Vinny's+Eatery,+860+Collins+St,+Docklands+VIC+3008" target="_blank" rel="noopener" class="small">Google Maps</a>
+    &middot;
+    <a href="https://www.openstreetmap.org/?mlat=-37.820957&mlon=144.94376&zoom=18" target="_blank" rel="noopener" class="small">OSM</a>
+  </p>
+  <p class="small text-secondary mb-0">Working session — open to all, explicitly for getting things done. Consolidate notes, draft action plans, follow up on commitments from Sunday.</p>
+</div>
+
+{% include "partials/updatesForm.njk" %}


### PR DESCRIPTION
June's Un-forum has passed, so the featured slot rolls to the next quarter. Dates are 19–21 September 2026 — Saturday to Monday, aligned with Software Freedom Day (Sat 19 Sep) and following the established dinner / unconference / breakfast shape.

- homeCards.json: new featured "Un-forum — September 2026" card; the June card drops to past:true alongside March and Canberra.
- src/posts/unforum-sept-2026.md: full program page cloned from June, with dates, permalink, back-nav (now pointing to June), form ids and every Google Calendar link updated. September is still AEST, so the UTC times carry over unchanged.
- src/assets/events/unforum-sept-2026.ics: matching calendar file.

Carried over from June and needing confirmation before this ships: venues (Crossways / inspire9 / Vinny's), the IGF submissions session, and the themes (swapped toward a Software Freedom Day flavour — Software Freedom, Open Source, Right to Repair). The June Luma RSVP button was dropped rather than reused; a September Luma link and a September preview banner still need adding.